### PR TITLE
[EDMTP-404/410] Fixed: Visibility action finds wrong wrapper for the .coral-Form-field wrapped in <span>

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/etoolbox-authoring-kit/depends-on/js/accessors/dependsOnCoralNoWrapperFieldsAccessor.js
+++ b/ui.apps/src/main/content/jcr_root/apps/etoolbox-authoring-kit/depends-on/js/accessors/dependsOnCoralNoWrapperFieldsAccessor.js
@@ -19,7 +19,7 @@
  * */
 (function ($, ns) {
     const NO_WRAPPER_FIELDS_SELECTOR =
-        '.coral-Form-fieldset, input[type=hidden], .coral-Heading, .coral3-Alert, .coral3-Button, a.coral-Link, span';
+        '.coral-Form-fieldset, input[type=hidden], .coral-Heading, .coral3-Alert, .coral3-Button, a.coral-Link, span:not(.coral-Form-field)';
 
     ns.ElementAccessors.registerAccessor({
         selector: NO_WRAPPER_FIELDS_SELECTOR,


### PR DESCRIPTION
https://jira.exadel.com/browse/EDMTP-410
https://jira.exadel.com/browse/EDMTP-404

**Nо Wrapper Fields Accessor** override default _findWrapper_ method to process components without _coral-Form-fieldwrapper_ (for instance, there is text widget that is just `<span>`, so we process selector: `span`).
Fixed: updated selector to the `span:not(.coral-Form-field)` to correctly process such widgets as pathBrowser (.coral-Form-field span with coral-Form-fieldwrapper).