### PR TITLE
[EAK-383] Fixed "File Already Exists" exception due to "version.info" present in a processed package

### DIFF
--- a/plugin/src/main/java/com/exadel/aem/toolkit/plugin/maven/PluginInfo.java
+++ b/plugin/src/main/java/com/exadel/aem/toolkit/plugin/maven/PluginInfo.java
@@ -14,13 +14,16 @@
 package com.exadel.aem.toolkit.plugin.maven;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Contains information about the current binary, such as build version and timestamp, to be used for package versioning
+ * Contains information about the current binary, such as build version and timestamp, to be used for package
+ * versioning
  */
 public class PluginInfo {
     private static final String MANIFEST_FILE_ADDRESS = "META-INF/MANIFEST.MF";
@@ -93,5 +96,16 @@ public class PluginInfo {
             // This is not intended to produce an effective exception
             return new PluginInfo();
         }
+    }
+
+    /**
+     * Creates a new {@link PluginInfo} instance and fills it with information passed to this method. This overload is
+     * designed to be used for testing purposes
+     * @param name    Name of the artifact to be used with this {@code PluginInfo}
+     * @param version Version of the artifact to be used with this {@code PluginInfo}
+     * @return {@code PluginInfo} object
+     */
+    static PluginInfo getInstance(String name, String version) {
+        return new PluginInfo(name, version, LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
     }
 }

--- a/plugin/src/main/java/com/exadel/aem/toolkit/plugin/writers/PackageWriter.java
+++ b/plugin/src/main/java/com/exadel/aem/toolkit/plugin/writers/PackageWriter.java
@@ -117,6 +117,7 @@ public class PackageWriter implements AutoCloseable {
         Path infoFilePath = infoDirPath.resolve(PACKAGE_INFO_FILE_NAME);
         try {
             Files.createDirectories(infoDirPath);
+            Files.deleteIfExists(infoFilePath);
             Files.createFile(infoFilePath);
         } catch (IOException e) {
             PluginRuntime.context().getExceptionHandler().handle(e);

--- a/plugin/src/test/com/exadel/aem/toolkit/plugin/AllTests.java
+++ b/plugin/src/test/com/exadel/aem/toolkit/plugin/AllTests.java
@@ -39,6 +39,7 @@ import com.exadel.aem.toolkit.plugin.targets.TargetsTest;
 import com.exadel.aem.toolkit.plugin.utils.AnnotationUtilTest;
 import com.exadel.aem.toolkit.plugin.utils.ordering.TopologicalSorterTest;
 import com.exadel.aem.toolkit.plugin.validators.ValidatorsTest;
+import com.exadel.aem.toolkit.plugin.writers.PackageInfoTest;
 
 /**
  * Shortcut class for running all available test cases in a batch
@@ -67,6 +68,8 @@ import com.exadel.aem.toolkit.plugin.validators.ValidatorsTest;
 
     ValidatorsTest.class,
     TerminateOnTest.class,
+
+    PackageInfoTest.class
 })
 public class AllTests {
     @BeforeClass

--- a/plugin/src/test/com/exadel/aem/toolkit/plugin/maven/FileRenderingUtil.java
+++ b/plugin/src/test/com/exadel/aem/toolkit/plugin/maven/FileRenderingUtil.java
@@ -31,8 +31,6 @@ import com.exadel.aem.toolkit.plugin.writers.PackageWriter;
 class FileRenderingUtil {
     private static final Logger LOG = LoggerFactory.getLogger(FileRenderingUtil.class);
 
-    private static final String PROJECT_NAME = "test-package";
-
     private FileRenderingUtil() {
     }
 
@@ -58,7 +56,7 @@ class FileRenderingUtil {
             ? fileSystem.getPath(TestConstants.PACKAGE_ROOT_PATH + TestConstants.DEFAULT_COMPONENT_NAME)
             : createdFilesPath;
 
-        PackageWriter.forFileSystem(fileSystem, PROJECT_NAME).write(testable);
+        PackageWriter.forFileSystem(fileSystem, TestConstants.DEFAULT_PROJECT_NAME).write(testable);
 
         Map<String, String> actualFiles = getFiles(effectiveCreatedFilesPath);
         Map<String, String> expectedFiles = getFiles(sampleFilesPath);
@@ -78,7 +76,7 @@ class FileRenderingUtil {
                 files.put(filePath.getFileName().toString(), String.join("", Files.readAllLines(filePath)));
             }
         } catch (NullPointerException | IOException ex) {
-            LOG.error("Could not read the package " + componentPath, ex);
+            LOG.error("Could not read the package {}", componentPath, ex);
         }
         return files;
     }

--- a/plugin/src/test/com/exadel/aem/toolkit/plugin/maven/PluginContextRenderingRule.java
+++ b/plugin/src/test/com/exadel/aem/toolkit/plugin/maven/PluginContextRenderingRule.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -111,5 +112,9 @@ public class PluginContextRenderingRule extends PluginContextRule {
                     e.getMessage().contains(message));
             }
         }
+    }
+
+    public Map<String, String> getPackageVersionInfo() {
+        return VersionInfoRenderingUtil.getVersionInfo(fileSystem);
     }
 }

--- a/plugin/src/test/com/exadel/aem/toolkit/plugin/maven/TestConstants.java
+++ b/plugin/src/test/com/exadel/aem/toolkit/plugin/maven/TestConstants.java
@@ -22,6 +22,8 @@ public class TestConstants {
     public static final String RESOURCE_FOLDER_DEPENDSON = "handlers/dependsOn";
     public static final String RESOURCE_FOLDER_WIDGETS = "handlers/widgets";
 
+    public static final String DEFAULT_PROJECT_NAME = "test-package";
+
     public static final String DEFAULT_COMPONENT_NAME = "test-component";
     public static final String NONEXISTENT_COMPONENT_NAME = "nonexistent/component";
     public static final String DEFAULT_COMPONENT_TITLE = "Test Component";
@@ -37,6 +39,8 @@ public class TestConstants {
     public static final String LABEL_TAB_5 = "Fifth tab";
     public static final String LABEL_TAB_6 = "Sixth tab";
     public static final String LABEL_TAB_7 = "Seventh tab";
+
+    public static final String PROPERTY_TIMESTAMP = "timestamp";
 
     private TestConstants() {
     }

--- a/plugin/src/test/com/exadel/aem/toolkit/plugin/maven/VersionInfoRenderingUtil.java
+++ b/plugin/src/test/com/exadel/aem/toolkit/plugin/maven/VersionInfoRenderingUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exadel.aem.toolkit.plugin.maven;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.collect.ImmutableMap;
+
+import com.exadel.aem.toolkit.plugin.utils.DialogConstants;
+import com.exadel.aem.toolkit.plugin.writers.PackageWriter;
+
+class VersionInfoRenderingUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(VersionInfoRenderingUtil.class);
+
+    private static final String PACKAGE_INFO_PATH = "META-INF/etoolbox-authoring-kit/version.info";
+    private static final String PROPERTY_VERSION = "version";
+    private static final String ARTIFACT_NAME = "EAK-Test";
+    private static final String ARTIFACT_VERSION = "1.0";
+
+    private VersionInfoRenderingUtil() {
+    }
+
+    public static Map<String, String> getVersionInfo(FileSystem fileSystem) {
+        PackageWriter
+            .forFileSystem(fileSystem, TestConstants.DEFAULT_PROJECT_NAME)
+            .writeInfo(PluginInfo.getInstance(ARTIFACT_NAME, ARTIFACT_VERSION));
+        Path infoFilePath = fileSystem.getRootDirectories().iterator().next().resolve(PACKAGE_INFO_PATH);
+        try {
+            List<String> lines = Files.readAllLines(infoFilePath);
+            return lines.size() >= 3
+                ? ImmutableMap.of(
+                DialogConstants.PN_NAME, lines.get(0),
+                PROPERTY_VERSION, lines.get(1),
+                TestConstants.PROPERTY_TIMESTAMP, lines.get(2))
+                : Collections.emptyMap();
+        } catch (IOException ex) {
+            LOG.error("Could not read the package info file {}", infoFilePath, ex);
+        }
+        return Collections.emptyMap();
+    }
+}

--- a/plugin/src/test/com/exadel/aem/toolkit/plugin/validators/ValidatorsTest.java
+++ b/plugin/src/test/com/exadel/aem/toolkit/plugin/validators/ValidatorsTest.java
@@ -16,7 +16,6 @@ package com.exadel.aem.toolkit.plugin.validators;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import com.exadel.aem.toolkit.plugin.exceptions.ValidationException;
 import com.exadel.aem.toolkit.plugin.maven.FileSystemRule;
@@ -32,9 +31,6 @@ public class ValidatorsTest {
 
     @Rule
     public PluginContextRenderingRule pluginContext = new PluginContextRenderingRule(fileSystemHost.getFileSystem());
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void testNonBlankValidation() {

--- a/plugin/src/test/com/exadel/aem/toolkit/plugin/writers/PackageInfoTest.java
+++ b/plugin/src/test/com/exadel/aem/toolkit/plugin/writers/PackageInfoTest.java
@@ -39,7 +39,6 @@ public class PackageInfoTest {
 
     @Test
     public void testCreatePackageInfo() {
-        // Throws a wrapped FileAlreadyExistsException unless a check for an existing "version.info" file is implemented
         Map<String, String> versionInfo1 = pluginContext.getPackageVersionInfo();
         String timestampString1 = versionInfo1.getOrDefault(TestConstants.PROPERTY_TIMESTAMP, StringUtils.EMPTY);
 

--- a/plugin/src/test/com/exadel/aem/toolkit/plugin/writers/PackageInfoTest.java
+++ b/plugin/src/test/com/exadel/aem/toolkit/plugin/writers/PackageInfoTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.exadel.aem.toolkit.plugin.writers;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.exadel.aem.toolkit.plugin.maven.FileSystemRule;
+import com.exadel.aem.toolkit.plugin.maven.PluginContextRenderingRule;
+import com.exadel.aem.toolkit.plugin.maven.TestConstants;
+import com.exadel.aem.toolkit.plugin.maven.ThrowsPluginException;
+
+@ThrowsPluginException
+public class PackageInfoTest {
+
+    @ClassRule
+    public static FileSystemRule fileSystemHost = new FileSystemRule();
+
+    @Rule
+    public PluginContextRenderingRule pluginContext = new PluginContextRenderingRule(fileSystemHost.getFileSystem());
+
+    @Test
+    public void testCreatePackageInfo() {
+        // Throws a wrapped FileAlreadyExistsException unless a check for an existing "version.info" file is implemented
+        Map<String, String> versionInfo1 = pluginContext.getPackageVersionInfo();
+        String timestampString1 = versionInfo1.getOrDefault(TestConstants.PROPERTY_TIMESTAMP, StringUtils.EMPTY);
+
+        Map<String, String> versionInfo2 = pluginContext.getPackageVersionInfo();
+        String timestampString2 = versionInfo2.getOrDefault(TestConstants.PROPERTY_TIMESTAMP, StringUtils.EMPTY);
+
+        Assert.assertTrue(StringUtils.isNoneEmpty(timestampString1, timestampString2));
+        LocalDateTime timestamp1 = LocalDateTime.parse(timestampString1, DateTimeFormatter.ISO_DATE_TIME);
+        LocalDateTime timestamp2 = LocalDateTime.parse(timestampString2, DateTimeFormatter.ISO_DATE_TIME);
+        Assert.assertFalse(timestamp2.isBefore(timestamp1));
+    }
+}


### PR DESCRIPTION
[EAK-383] Bug fixed: existing file deleting added at PackageWriter.writeInfo to avoid java.nio.file.FileAlreadyExistsException.