### PR TITLE
[EAK-598] Fixed the exception related to unavailability of editConfig inside the Developer layer

### DIFF
--- a/core/src/main/resources/policy-management/eakApplyTopLevelPolicy.js
+++ b/core/src/main/resources/policy-management/eakApplyTopLevelPolicy.js
@@ -1,8 +1,4 @@
 window.eakApplyTopLevelPolicy = (editable) => {
-    const currentLayer = getCurrentLayerName();
-    if (currentLayer !== 'edit') {
-        return;
-    }
     const {config} = editable;
     const rules = JSON.parse('%s').rules;
     const containers = rules.flatMap((rule) => rule.containers);
@@ -19,9 +15,3 @@ window.eakApplyTopLevelPolicy = (editable) => {
     config.eakResourceName = resName;
 };
 
-function getCurrentLayerName() {
-    if (!Granite.author || !Granite.author.layerManager || !Granite.author.layerManager.getCurrentLayer) {
-        return null;
-    }
-    return (Granite.author.layerManager.getCurrentLayer() || '').toLowerCase();
-}

--- a/ui.apps/src/main/content/jcr_root/apps/etoolbox-authoring-kit/policies/js/policyManagement.js
+++ b/ui.apps/src/main/content/jcr_root/apps/etoolbox-authoring-kit/policies/js/policyManagement.js
@@ -23,6 +23,9 @@
     ns.PolicyResolver.cache = new Map();
 
     $(document).on('cq-editables-loaded', function (event) {
+        if (getCurrentLayerName() !== 'edit') {
+            return;
+        }
         if (window.eakApplyTopLevelPolicy) {
             event.editables.forEach((e) => window.eakApplyTopLevelPolicy(e));
         }
@@ -34,6 +37,17 @@
             resolve(allowed, componentList, this, rules);
         };
     };
+
+    /**
+     * Retrieves the name of the current TouchUI layer to decide whether the policy should be applied
+     * @returns {string|null}
+     */
+    function getCurrentLayerName() {
+        if (!Granite.author || !Granite.author.layerManager || !Granite.author.layerManager.getCurrentLayer) {
+            return null;
+        }
+        return (Granite.author.layerManager.getCurrentLayer() || '').toLowerCase();
+    }
 
     /**
      * Modifies the OOTB {@code _findAllowedComponentsFromPolicy} function to make it return an empty array instead of


### PR DESCRIPTION
Fixes #598 
Solution per https://experienceleaguecommunities.adobe.com/t5/adobe-experience-manager/how-do-i-determine-current-mode-client-side/m-p/180202